### PR TITLE
fix(flow): wrong event type when emit event

### DIFF
--- a/lib/src/model/flow.dart
+++ b/lib/src/model/flow.dart
@@ -130,7 +130,7 @@ class FlowLog {
       _hasError = true;
       _emit(FlowLogEvent.error, this);
     } else {
-      _emit(FlowLogEvent.error, this);
+      _emit(FlowLogEvent.log, this);
     }
     this.logs!.add(log);
     FlowCenter.instance._notify();


### PR DESCRIPTION
when adding a log to the FlowLog, the type of the event should be FlowLogEvent.log if there is no 'error'